### PR TITLE
Add a setting to prevent moving disabled elements

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -69,6 +69,7 @@ var demo2 = $('.demo2').bootstrapDualListbox({
   selectedListLabel: 'Selected',
   preserveSelectionOnMove: 'moved',
   moveOnSelect: false,
+  moveDisabledElements: false,
   nonSelectedFilter: 'ion ([7-9]|[1][0-2])'
 });</pre>
     </div>
@@ -77,11 +78,11 @@ var demo2 = $('.demo2').bootstrapDualListbox({
         <option value="option1">Option 1</option>
         <option value="option2">Option 2</option>
         <option value="option3" selected="selected">Option 3</option>
-        <option value="option4">Option 4</option>
+        <option disabled value="option4">Option 4</option>
         <option value="option5">Option 5</option>
-        <option value="option6" selected="selected">Option 6</option>
+        <option disabled value="option6" selected="selected">Option 6</option>
         <option value="option7">Option 7</option>
-        <option value="option8">Option 8</option>
+        <option disabled value="option8">Option 8</option>
         <option value="option9">Option 9</option>
         <option value="option0">Option 10</option>
         <option value="option0">Option 11</option>
@@ -101,6 +102,7 @@ var demo2 = $('.demo2').bootstrapDualListbox({
           selectedListLabel: 'Selected',
           preserveSelectionOnMove: 'moved',
           moveOnSelect: false,
+          moveDisabledElements: false,
           nonSelectedFilter: 'ion ([7-9]|[1][0-2])'
         });
       </script>
@@ -235,6 +237,10 @@ $("#demo2-add-clear").click(function() {
         <td><code><strong>false</strong></code>: set this to <code>true</code> to filter the options according to their values and not their HTML contents.</td>
       </tr>
       <tr>
+        <td><code>moveDisabledElements</code></td>
+        <td><code><strong>true</strong></code>: set this to <code>false</code> to prevent disabled items from being moved.</td>
+      </tr>
+      <tr>
         <td><code>eventMoveOverride</code></td>
         <td><code><strong>false</strong></code>: set this to <code>true</code> to allow your own implementation of the move event.</td>
       </tr>
@@ -367,6 +373,10 @@ $(selector).bootstrapDualListbox(methodName, parameter);</pre>
       <tr>
         <td><code>setFilterOnValues(value, refresh)</code></td>
         <td>change the <code>filterOnValues</code> parameter.</td>
+      </tr>
+      <tr>
+        <td><code>setMoveDisabledElements(value, refresh)</code></td>
+        <td>change the <code>moveDisabledElements</code> parameter.</td>
       </tr>
       <tr>
         <td><code>setEventMoveOverride(value, refresh)</code></td>

--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -23,6 +23,7 @@
       infoTextEmpty: 'Empty list',                                                        // when there are no options present in the list
       filterOnValues: false,                                                              // filter by selector's values, boolean
       sortByInputOrder: false,
+      moveDisabledElements: true,                                                         // boolean, if false do not move disabled elements (true by default to prevent breaking change)
       eventMoveOverride: false,                                                           // boolean, allows user to unbind default event behaviour and run their own instead
       eventMoveAllOverride: false,                                                        // boolean, allows user to unbind default event behaviour and run their own instead
       eventRemoveOverride: false,                                                         // boolean, allows user to unbind default event behaviour and run their own instead

--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -556,7 +556,6 @@
       }
       return this.element;
     },
-
     setRemoveSelectedLabel: function(value, refresh) {
       this.settings.removeSelectedLabel = value;
       this.elements.removeButton.attr('title', value);

--- a/src/jquery.bootstrap-duallistbox.js
+++ b/src/jquery.bootstrap-duallistbox.js
@@ -218,7 +218,12 @@
       saveSelections(dualListbox, 1);
     }
 
-    dualListbox.elements.select1.find('option:selected').each(function(index, item) {
+    var options = dualListbox.element.find('option:selected');
+    if (!dualListbox.settings.moveDisabledElements) {
+      options = options.filter(':enabled');
+    }
+
+    options.each(function(index, item) {
       var $item = $(item);
       if (!$item.data('filtered1')) {
         changeSelectionState(dualListbox, $item.data('original-index'), true);
@@ -242,7 +247,12 @@
       saveSelections(dualListbox, 2);
     }
 
-    dualListbox.elements.select2.find('option:selected').each(function(index, item) {
+    var options = dualListbox.element.find('option:selected');
+    if (!dualListbox.settings.moveDisabledElements) {
+      options = options.filter(':enabled');
+    }
+
+    options.each(function(index, item) {
       var $item = $(item);
       if (!$item.data('filtered2')) {
         changeSelectionState(dualListbox, $item.data('original-index'), false);
@@ -265,7 +275,12 @@
       saveSelections(dualListbox, 1);
     }
 
-    dualListbox.element.find('option').each(function(index, item) {
+    var options = dualListbox.element.find('option');
+    if (!dualListbox.settings.moveDisabledElements) {
+      options = options.filter(':enabled');
+    }
+
+    options.each(function(index, item) {
       var $item = $(item);
       if (!$item.data('filtered1')) {
         $item.prop('selected', true);
@@ -286,7 +301,12 @@
       saveSelections(dualListbox, 2);
     }
 
-    dualListbox.element.find('option').each(function(index, item) {
+    var options = dualListbox.element.find('option');
+    if (!dualListbox.settings.moveDisabledElements) {
+      options = options.filter(':enabled');
+    }
+
+    options.each(function(index, item) {
       var $item = $(item);
       if (!$item.data('filtered2')) {
         $item.prop('selected', false);
@@ -438,6 +458,7 @@
       this.setFilterPlaceHolder(this.settings.filterPlaceHolder);
       this.setMoveSelectedLabel(this.settings.moveSelectedLabel);
       this.setMoveAllLabel(this.settings.moveAllLabel);
+      this.setMoveDisabledElements(this.settings.moveDisabledElements);
       this.setRemoveSelectedLabel(this.settings.removeSelectedLabel);
       this.setRemoveAllLabel(this.settings.removeAllLabel);
       this.setMoveOnSelect(this.settings.moveOnSelect);
@@ -528,6 +549,14 @@
       }
       return this.element;
     },
+    setMoveDisabledElements: function(value, refresh) {
+      this.settings.moveDisabledElements = value;
+      if (refresh) {
+        refreshSelects(this);
+      }
+      return this.element;
+    },
+
     setRemoveSelectedLabel: function(value, refresh) {
       this.settings.removeSelectedLabel = value;
       this.elements.removeButton.attr('title', value);


### PR DESCRIPTION
```moveDisabledElements``` is enabled by default (to not break existing functionality)

Setting it to false will prevent disabled elements from being moved between lists.